### PR TITLE
Adição da funcionalidade de Filtrar pares ao código

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # Exercicio_9v2_Paradigmas
+
+## Função Filtrar Pares
+
+Essa função filtraPares recebe um array de inteiros e retorna um novo array contendo apenas os números pares.
+
+entrada -> {11, 2, 2, 2, 5, 3, 3, 11, 5, 11, 13, 5, 2, 3, 11}
+saída -> [2 2 2 2]
+

--- a/StrategyFuncs/filtrarPares.go
+++ b/StrategyFuncs/filtrarPares.go
@@ -1,0 +1,17 @@
+package StrategyFuncs
+
+//Essa função filtraPares recebe um array de inteiros e retorna um novo array contendo apenas os números pares.
+func FiltraPares(array []int) []int {
+	rem := make([]int, len(array))
+	k := 0
+
+	for i := 0; i < len(array); i++ {
+		if array[i]%2 == 0 {
+			rem[k] = array[i]
+			k++
+		}
+	}
+	return rem[0:k]
+}
+
+

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/rafaeljosebraga/Exercicio_9v2_Paradigmas
+
+go 1.18

--- a/main.go
+++ b/main.go
@@ -15,4 +15,7 @@ func main() {
 	primes := []int{11, 2, 2, 2, 5, 3, 3, 11, 5, 11, 13, 5, 2, 3, 11}
 	// executar_estrategia(&primes, removeDuplicates)
 	fmt.Println("Remoção de duplicatas: ",primes)
+	primes2 := []int{11, 2, 2, 2, 5, 3, 3, 11, 5, 11, 13, 5, 2, 3, 11}
+	executar_estrategia(&primes, StrategyFuncs.FiltraPares)
+	fmt.Println("Pares Filtrados: ",primes2)
 }

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"StrategyFuncs/strategy"
+	"github.com/rafaeljosebraga/Exercicio_9v2_Paradigmas/StrategyFuncs"
 )
 
 type listFunction func([]int) []int
@@ -16,6 +16,6 @@ func main() {
 	// executar_estrategia(&primes, removeDuplicates)
 	fmt.Println("Remoção de duplicatas: ",primes)
 	primes2 := []int{11, 2, 2, 2, 5, 3, 3, 11, 5, 11, 13, 5, 2, 3, 11}
-	executar_estrategia(&primes, StrategyFuncs.FiltraPares)
+	executar_estrategia(&primes2, StrategyFuncs.FiltraPares)
 	fmt.Println("Pares Filtrados: ",primes2)
 }

--- a/main.go
+++ b/main.go
@@ -15,7 +15,6 @@ func main() {
 	primes := []int{11, 2, 2, 2, 5, 3, 3, 11, 5, 11, 13, 5, 2, 3, 11}
 	// executar_estrategia(&primes, removeDuplicates)
 	fmt.Println("Remoção de duplicatas: ",primes)
-	primes2 := []int{11, 2, 2, 2, 5, 3, 3, 11, 5, 11, 13, 5, 2, 3, 11}
-	executar_estrategia(&primes2, StrategyFuncs.FiltraPares)
-	fmt.Println("Pares Filtrados: ",primes2)
+	executar_estrategia(&primes, StrategyFuncs.FiltraPares)
+	fmt.Println("Pares Filtrados: ",primes)
 }


### PR DESCRIPTION
# Exercicio_9v2_Paradigmas

## Função Filtrar Pares

Essa função filtraPares recebe um array de inteiros e retorna um novo array contendo apenas os números pares.

entrada -> {11, 2, 2, 2, 5, 3, 3, 11, 5, 11, 13, 5, 2, 3, 11}
saída -> [2 2 2 2]

Importante notar que na hora de rodar na máquina pode ser necessário verificar os imports.